### PR TITLE
Update to cosign v2.4.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     branches: ["main"]
 
 env:
-  GOLANG_VERSION: "1.22"
+  GOLANG_VERSION: "1.23"
 
 jobs:
   build:
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4.1.2
         with:
           repository: sigstore/cosign
-          ref: v2.4.0
+          ref: v2.4.3
 
       - name: Setup go ${{ env.GOLANG_VERSION }}
         uses: actions/setup-go@v5.0.0


### PR DESCRIPTION
Use the same major Go version as upstream releases do.